### PR TITLE
clear form button fixed

### DIFF
--- a/pages/Search/Search.hbs
+++ b/pages/Search/Search.hbs
@@ -76,7 +76,7 @@
 
         <div class=search-controls>
           <button class='button green' id=quick-search-button type=submit>Search</button>
-          <button class='button blue' id=quick-reset-button type=reset>Clear form</button>
+          <button class='button blue' id=quick-reset-button type=button>Clear form</button>
         </div>
 
       </fieldset>
@@ -285,7 +285,7 @@
 
       <div class=search-controls>
         <button class='button green' id=advanced-search-button type=submit>Search</button>
-        <button class='button blue' id=advanced-reset-button type=reset>Clear form</button>
+        <button class='button blue' id=advanced-reset-button type=button>Clear form</button>
       </div>
 
       <p class='complex-searches help-text'>For more complex searches not supported here, we recommend exporting the data in CSV or JSON format using the download buttons at the bottom of the results table. Alternatively, you can also download the entire database <a class=link href=https://zenodo.org/doi/10.5281/zenodo.11459862>here</a>.</p>

--- a/pages/Search/scripts/AdvancedSearch.js
+++ b/pages/Search/scripts/AdvancedSearch.js
@@ -11,6 +11,7 @@ export default class AdvancedSearch {
     this.logic         = document.getElementById(`logic-select`)
     this.regex         = document.getElementById(`advanced-regex-box`)
     this.tagsBox       = document.getElementById(`tags-box`)
+    this.resetButton   = document.getElementById('advanced-reset-button')
   }
 
   listen() {
@@ -21,6 +22,11 @@ export default class AdvancedSearch {
     this.language.addEventListener(`input`, this.save.bind(this))
     this.logic.addEventListener(`input`, this.save.bind(this))
     this.regex.addEventListener(`input`, this.save.bind(this))
+
+    // reset button functionality
+    this.resetButton.addEventListener(`click`, this.reset.bind(this))
+
+    console.log('resetButton:', this.resetButton)
   }
 
   render() {
@@ -71,6 +77,30 @@ export default class AdvancedSearch {
       }
     }
 
+  }
+
+  reset(ev) {
+    ev.preventDefault()
+    localStorage.removeItem(`language`)
+    localStorage.removeItem(`logic`)
+    
+    // Reset all text/search inputs
+    const fields = document.querySelectorAll(`#advanced-search-form [type=search]`)
+    for (const field of fields) field.value = ``
+
+    // Reset checkboxes
+    this.caseSensitive.checked = false
+    this.diacritics.checked = false
+    this.regex.checked = false
+    document.getElementById(`primary-box`).checked = false
+    document.getElementById(`secondary-box`).checked = false
+
+    // Reset dropdowns to default
+    this.language.value = `all`
+    this.logic.value = `all`
+    document.getElementById(`subcategory-select`).value = ``
+    document.getElementById(`type-select`).value = ``
+    document.getElementById(`bib-select`).value = ``
   }
 
 }

--- a/pages/Search/scripts/QuickSearch.js
+++ b/pages/Search/scripts/QuickSearch.js
@@ -19,6 +19,11 @@ export default class QuickSearch {
     this.form.addEventListener(`submit`, this.validate.bind(this))
     this.language.addEventListener(`input`, this.save.bind(this))
     this.regex?.addEventListener(`input`, this.save.bind(this))
+
+    // reset button functionality
+    this.resetButton.addEventListener(`click`, this.reset.bind(this))
+
+    console.log('resetButton:', this.resetButton)
   }
 
   render() {
@@ -64,6 +69,13 @@ export default class QuickSearch {
       this.search.reportValidity()
     }
 
+  }
+
+  reset(ev) {
+    ev.preventDefault()
+    localStorage.removeItem(`language`)
+    this.search.value = ``
+    this.language.value = `all`
   }
 
 }


### PR DESCRIPTION
clear form button now works on both quick and advanced search to clear out all options, even after searching. fixes #227. fixed by adding reset function to QuickSearch.js and AdvancedSearch.js instead of using default html clear button type. Should work well, since the clear form button keeps the search results instead of refreshing the page and wiping everything